### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,5 @@
 {
-   "license" : "perl",
+   "license" : "Artistic-2.0",
    "name" : "Lumberjack::Application",
    "version" : "0.0.4",
    "source-url" : "git@github.com:jonathanstowe/Lumberjack-Application.git",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license